### PR TITLE
Add debug to the result of a failed `is_variant`.

### DIFF
--- a/src/matchers/variant.rs
+++ b/src/matchers/variant.rs
@@ -34,6 +34,7 @@ use super::super::*;
 /// ```
 /// # #[macro_use] extern crate galvanic_assert;
 /// # fn main() {
+/// #[derive(Debug)]
 /// enum MyEnum { Foo, Bar(i32), Baz{x: i32} }
 /// assert_that!(&MyEnum::Baz{x: 2}, is_variant!(MyEnum::Baz));
 /// # }
@@ -46,8 +47,8 @@ macro_rules! is_variant {
             let builder = MatchResultBuilder::for_("is_variant");
             match actual {
                 &$variant {..} => builder.matched(),
-                _ => builder.failed_because(
-                        &format!("passed variant does not match '{}'", stringify!($variant))
+                x => builder.failed_because(
+                        &format!("passed variant of {:?} does not match '{}'", x, stringify!($variant))
                 )
             }
         })

--- a/tests/combinator_matchers.rs
+++ b/tests/combinator_matchers.rs
@@ -114,6 +114,7 @@ mod combining_variant_matchers {
     use galvanic_assert::matchers::*;
 
     #[allow(dead_code)]
+    #[derive(Debug)]
     enum Variants {
         First,
         Second,


### PR DESCRIPTION
No idea if you actually want to make `Debug` a requirement here.

I use `Debug` on all my types, `std::assert_eq` requires `Debug`, and think it makes the error messages when variant fails much more useful. I wrote this for my own use and figured I should PR it in case you'd like to add it.